### PR TITLE
Fixing SampleScene can't find TimedType.cs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ ExportedObj/
 # Unity3D generated meta files
 *.pidb.meta
 *.pdb.meta
-*.meta
 
 # Unity3D Generated File On Crash Reports
 sysinfo.txt

--- a/Assets/TimedType.meta
+++ b/Assets/TimedType.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6ccbc814f57da29478ce9f509289df72
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/TimedType/Scenes.meta
+++ b/Assets/TimedType/Scenes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4f704ae4b4f98ae41a0bce26658850c1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/TimedType/Scenes/SampleScene.unity.meta
+++ b/Assets/TimedType/Scenes/SampleScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 99c9720ab356a0642a771bea13969a05
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/TimedType/Scripts.meta
+++ b/Assets/TimedType/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5e53b99fe89fc4047976eadfa97de96c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/TimedType/Scripts/TimedTextEntry.cs.meta
+++ b/Assets/TimedType/Scripts/TimedTextEntry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 09c6eb4f1a805f3448ebcc1b4096e1d4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Unity needs the .meta files to find scripts referenced in SampleScene. Cut a little too deep with the gitignore.